### PR TITLE
Fixes #7 by adding missing LaTeX column break characters

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -5,7 +5,6 @@
 - [ ] Add the calculated limiting magnitude to the article
 - [ ] Add description of `limit.ipynb` to `overview.md`
 - [ ] Consider whether it is more appropriate to report fluxes (rather than flux densities) in the seeing simulation
-- [ ] Add horizontal, separating lines to tables where applicable to separate the stacked and individual spectra
 - [ ] Update flow chart to reflect that the `galfit.ipynb` output also feeds into the final article
 - [ ] Add all Python packages and verisons to the software credit in the article
 - [ ] Determine the units of the Lyα maps and verify the units stated in the documentation and code comments 
@@ -14,6 +13,7 @@
 
 ### Closed
 
+- [x] Consider how to determine the number of significant figures to report for the depth of the F275W image (closed 22 August 2024)
 - [x] Optimize the convolutions in `esc.ipynb` and `seeing.ipynb` so that they only calculate the effect of the convolution on the pixels summed for photometric measurements (closed 20 August 2024 by #15)
 - [x] Create a virtual environment with the latest Python and package versions and execute the project's code with the environment (closed 15 August 2024 by #14)
 - [x] Create a `requirements.txt` file listing the package versions the project uses (closed 15 August 2024 by #14)

--- a/lya.ipynb
+++ b/lya.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 1,
    "id": "0f1beb15",
    "metadata": {},
    "outputs": [],
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 3,
    "id": "92eb6b9b",
    "metadata": {},
    "outputs": [],
@@ -1489,7 +1489,7 @@
     "        table = table + '\\hline\\n' if slit_id == 'M0' else table + ''\n",
     "\n",
     "        # Add the slit ID to the row\n",
-    "        table = table + f'{slit_id} '\n",
+    "        table = table + f'{slit_id} & '\n",
     "\n",
     "        # Get the best-fit Lya model parameters of the spectrum\n",
     "        params = np.loadtxt(f'{results}/lya_fits/{slit_id}/{slit_id}_mc_sim_lya_best_fit_model_parameters.txt', delimiter=' ', comments='#').T\n",
@@ -1644,7 +1644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 5,
    "id": "83b584ca",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
Fixes #7, which reported missing LaTeX column break characters in the Lyα best-fit model parameters table. The characters should have been in front of the slit ID entries in the table, since without them the slit IDs would appear merged with the first column of measurements in the table.